### PR TITLE
Fix empty pages crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Esta aplicación permite extraer y gestionar visitas de archivos PDF exportados desde Bookeo. Utiliza Streamlit y la API de Google Generative AI para procesar el documento y mostrar los datos de forma interactiva.
 
-> **Nota técnica**:  
+> **Nota técnica**:
 > Las primeras líneas de `app.py` establecen la variable de entorno `WATCHDOG_USE_POLLING` a `true` mediante `os.environ`. Esto soluciona el error "inotify watch limit reached" que puede aparecer en sistemas con un límite bajo de inotify watchers cuando Streamlit monitoriza archivos.
 
 ## Instalación
@@ -12,3 +12,23 @@ Esta aplicación permite extraer y gestionar visitas de archivos PDF exportados 
 
 ```bash
 pip install -r requirements.txt
+```
+
+## Configuración de secretos
+
+Crea un archivo `secrets.toml` en la raíz del proyecto con tu clave de API:
+
+```toml
+[api]
+API_KEY = "TU_CLAVE_AQUI"
+```
+
+## Uso
+
+Ejecuta la aplicación con Streamlit:
+
+```bash
+streamlit run app.py
+```
+
+Al abrir la URL indicada, podrás subir un PDF de Bookeo y gestionar las visitas de forma interactiva.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import os
+
 os.environ["WATCHDOG_USE_POLLING"] = "true"
 
 import base64
@@ -127,6 +128,18 @@ if cur_idx >= len(pages):
     st.session_state.current = 0
     cur_idx = 0
 
+# Si la lista de páginas está vacía, crear una nueva por defecto
+if not pages:
+    page_counter += 1
+    new_page = {
+        "id": str(uuid.uuid4()),
+        "name": f"Visita {page_counter}",
+        "df": None,
+        "created_at": datetime.now().isoformat(),
+    }
+    pages.append(new_page)
+    st.session_state.page_counter = page_counter
+
 page = pages[cur_idx]
 
 
@@ -159,6 +172,18 @@ with st.sidebar:
             ):
                 # Borra página y ajusta current si hace falta
                 del pages[i]
+
+                if not pages:
+                    page_counter += 1
+                    new_page = {
+                        "id": str(uuid.uuid4()),
+                        "name": f"Visita {page_counter}",
+                        "df": None,
+                        "created_at": datetime.now().isoformat(),
+                    }
+                    pages.append(new_page)
+                    st.session_state.page_counter = page_counter
+
                 if st.session_state.current >= len(pages):
                     st.session_state.current = max(0, len(pages) - 1)
                 save_cache(pages, page_counter)


### PR DESCRIPTION
## Summary
- ensure at least one page exists after cache cleanup or deletion
- recreate a blank page if the last page is removed
- extend README with setup and usage instructions

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_68833dda0bf4832ab78e9d4e5659287a